### PR TITLE
fix(makefile): corregir puertos a 5000:5000 e inyectar API_TOKEN en dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build:
 
 dev:
 	@echo "[+] Ejecutando entorno de desarrollo..."
-	docker run --rm -it -p 8080:80 $(IMAGE)
+	docker run --rm -it -p 5000:5000 -e API_TOKEN="clave-dev" $(IMAGE)
 	@echo "[->] dev finalizado."
 
 test:


### PR DESCRIPTION
Fixes #11 

Se corrigió el comando "make dev" que apuntaba al puerto 80.
Ahora apunta al puerto 5000 y pasa la variable "API_TOKEN" requerida para que la app arranque sin errores